### PR TITLE
some methods for handling singular resource case

### DIFF
--- a/test/resty/repo_test.exs
+++ b/test/resty/repo_test.exs
@@ -43,6 +43,26 @@ defmodule Resty.RepoTest do
     end
   end
 
+  test "show :ok" do
+    assert {:ok, [%Post{id: 1} | _]} = Repo.show(Post)
+    assert {:ok, []} = Repo.show(Subscriber)
+  end
+
+  test "show :error" do
+    assert {:error, %Error.ResourceNotFound{}} = Repo.show(Like)
+  end
+
+  test "show! ok" do
+    assert [%Post{id: 1} | _] = Repo.show!(Post)
+    assert [] = Repo.all!(Subscriber)
+  end
+
+  test "show! error" do
+    assert_raise Error.ResourceNotFound, fn ->
+      Repo.all!(Like)
+    end
+  end
+
   test "all :ok" do
     assert {:ok, [%Post{id: 1} | _]} = Repo.all(Post)
     assert {:ok, []} = Repo.all(Subscriber)
@@ -135,6 +155,14 @@ defmodule Resty.RepoTest do
 
       post |> Repo.save!()
     end
+  end
+
+  test "update singular :ok" do
+    {:ok, post} = Repo.find(Post, 1)
+
+    {:ok, updated_post} = %{post | name: "updated"} |> Repo.update()
+
+    assert "updated" == updated_post.name
   end
 
   test "update_attribute :ok" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -17,6 +17,7 @@ defmodule MockedConnection do
   mock(:get, "site.tld/posts/1", {:ok, @first_post |> Jason.encode!()})
   mock(:get, "site.tld/posts/2", {:ok, @second_post |> Jason.encode!()})
   mock(:post, "site.tld/posts")
+  mock(:put, "site.tld/posts")
   mock(:put, "site.tld/posts/1")
   mock(:put, "site.tld/posts/2", {:error, Resty.Error.ResourceInvalid.new()})
   mock(:delete, "site.tld/posts/1")


### PR DESCRIPTION
- show: alias for `all`
- update: behaves as `save` but without `id`